### PR TITLE
updating opencv library reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Default Python packages supported by the container
 
 **packages for image processing**
 - Pillow == 6.0.0
+- opencv-python==4.2.0.34
 
 **IBM specific python modules**
 - ibm_db == 3.0.1

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Default Python packages supported by the container
 **Crypto modules**
 - cryptography==2.9.1
 
+**3rd party API management**
+zeep==3.4.0
+
 ## Examples
 
 ### Hello Action

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,6 @@ dialogflow == 1.0.0
 
 # crypto packages
 cryptography==2.9.1
+
+# 3rd party API management
+zeep==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ sentry-sdk==0.12.2
 # AWS specific modules
 boto3==1.10.29
 botocore==1.13.29
-opencv==4.3.0
+opencv-python==4.2.0.34
 pynt==0.8.2
 pytz==2020.1
 


### PR DESCRIPTION
In a previous commit, the opencv package was wrongly added to the requirements file, with typos, avoiding to build properly the container